### PR TITLE
PropertyGridViewProvider improvements

### DIFF
--- a/UIAutomation/UIAutomationClient/System.Windows.Automation/LegacyIAccessiblePattern.cs
+++ b/UIAutomation/UIAutomationClient/System.Windows.Automation/LegacyIAccessiblePattern.cs
@@ -90,6 +90,11 @@ namespace System.Windows.Automation
 			}
 		}
 
+		public void DoDefaultAction ()
+		{
+			Source.DoDefaultAction ();
+		}
+
 		private AutomationElement element;
 		private bool cached;
 		private LegacyIAccessiblePatternInformation currentInfo;

--- a/UIAutomation/UIAutomationProvider/System.Windows.Automation.Provider/ILegacyIAccessibleProvider.cs
+++ b/UIAutomation/UIAutomationProvider/System.Windows.Automation.Provider/ILegacyIAccessibleProvider.cs
@@ -41,5 +41,7 @@ namespace System.Windows.Automation.Provider
 		int Role { get; }  // CLS-compliantment requires signed int instead of UInt32
 		int State { get; }  // CLS-compliantment requires signed int instead of UInt32
 		string Value { get; }
+
+		void DoDefaultAction ();
 	}
 }

--- a/UIAutomation/UIAutomationSource/Mono.UIAutomation.Source/ILegacyIAccessiblePattern.cs
+++ b/UIAutomation/UIAutomationSource/Mono.UIAutomation.Source/ILegacyIAccessiblePattern.cs
@@ -37,5 +37,7 @@ namespace Mono.UIAutomation.Source
 		int Role { get; }  // CLS-compliantment requires signed int instead of UInt32
 		int State { get; }  // CLS-compliantment requires signed int instead of UInt32
 		string Value { get; }
+
+		void DoDefaultAction ();
 	}
 }

--- a/UIAutomationWinforms/UIAutomationWinforms/Makefile.am
+++ b/UIAutomationWinforms/UIAutomationWinforms/Makefile.am
@@ -153,10 +153,10 @@ FILES =  \
 	Mono.UIAutomation.Winforms.Behaviors/PrintPreviewControl/ScrollProviderBehavior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/ProgressBar/RangeValueProviderBehavior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/CategoryInvokeProviderBehavior.cs \
+	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/GridItemLegacyIAccessibleProviderBehavior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/GridProviderBehavior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/ListItemChildValueProviderBeahvior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/ListItemGridItemProviderBehavior.cs \
-	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/ListItemLegacyIAccessibleProviderBehavior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/ListItemNameValueProviderBeahvior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/ListItemSelectionItemProviderBehavior.cs \
 	Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/ListItemTableItemProviderBehavior.cs \

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/GridItemLegacyIAccessibleProviderBehavior.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Behaviors/PropertyGrid/GridItemLegacyIAccessibleProviderBehavior.cs
@@ -28,14 +28,13 @@ using SWF = System.Windows.Forms;
 
 namespace Mono.UIAutomation.Winforms.Behaviors.PropertyGrid
 {
-	internal class ListItemLegacyIAccessibleProviderBehavior
+	internal class GridItemLegacyIAccessibleProviderBehavior
 		: ProviderBehavior, ILegacyIAccessibleProvider
 	{
 #region Constructors
-		public ListItemLegacyIAccessibleProviderBehavior (ListItemProvider provider)
+		public GridItemLegacyIAccessibleProviderBehavior (PropertyGridListItemProvider provider)
 			: base (provider)
 		{
-			this.provider = (PropertyGridListItemProvider) provider;
 		}
 #endregion
 
@@ -78,54 +77,46 @@ namespace Mono.UIAutomation.Winforms.Behaviors.PropertyGrid
 #endregion
 
 #region ILegacyIAccessibleProvider Specialization
-		public int ChildId
-		{
+		public int ChildId {
 			get { return 0; }
 		}
 
-		public string DefaultAction
-		{
+		public string DefaultAction {
 			get { return ""; }
 		}
 
-		public string Description
-		{
+		public string Description {
 			get { return ""; }
 		}
 
-		public string Help
-		{
+		public string Help {
 			get { return ""; }
 		}
 
-		public string KeyboardShortcut
-		{
+		public string KeyboardShortcut {
 			get { return ""; }
 		}
 
-		public string Name
-		{
-			get { return provider.Name; }
+		public string Name {
+			get { return GridItemProvider.Name; }
 		}
 
-		public int Role
-		{
+		public int Role {
 			get { return (int)SWF.AccessibleRole.Row; }
 		}
 
-		public int State
-		{
+		public int State {
 			get {
 				var state = SWF.AccessibleStates.Selectable;
 
-				if (provider.IsReadOnly)
+				if (GridItemProvider.IsReadOnly)
 					state |= SWF.AccessibleStates.ReadOnly;
 
-				if (provider.PropertyGridViewProvider.IsItemSelected (provider))
+				if (GridItemProvider.PropertyGridViewProvider.IsItemSelected (GridItemProvider))
 					state |= SWF.AccessibleStates.Selected;
 
-				if (provider.Entry.Expandable) {
-					if (provider.Entry.Expanded)
+				if (GridEntry.Expandable) {
+					if (GridEntry.Expanded)
 						state |= SWF.AccessibleStates.Expanded;
 					else
 						state |= SWF.AccessibleStates.Collapsed;
@@ -135,14 +126,29 @@ namespace Mono.UIAutomation.Winforms.Behaviors.PropertyGrid
 			}
 		}
 
-		public string Value
+		public string Value {
+			get { return GridItemProvider.Value; }
+		}
+
+		public void DoDefaultAction ()
 		{
-			get { return provider.Value; }
+			if (!GridEntry.Expandable)
+				return;
+			GridItemProvider.PropertyGridViewProvider.SelectItem (GridItemProvider);
+			GridEntry.Expanded = !GridEntry.Expanded;
 		}
 #endregion
 
-#region Private Fields
-		private PropertyGridListItemProvider provider;
+#region Private properties
+		private PropertyGridListItemProvider GridItemProvider
+		{
+			get { return (PropertyGridListItemProvider) Provider; }
+		}
+
+		private SWF.PropertyGridInternal.GridEntry GridEntry
+		{
+			get { return GridItemProvider.Entry; }
+		}
 #endregion
 	}
 }

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/FragmentControlProvider.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/FragmentControlProvider.cs
@@ -265,7 +265,7 @@ namespace Mono.UIAutomation.Winforms
 		
 		public virtual void FinalizeChildControlStructure ()
 		{
-			if (Control != null) {				
+			if (Control != null) {
 				Control.ControlAdded -= OnControlAdded;
 				Control.ControlRemoved -= OnControlRemoved;
 				Control.VisibleChanged -= OnControlVisibleChanged;

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/PropertyGridViewProvider.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/PropertyGridViewProvider.cs
@@ -261,7 +261,7 @@ namespace Mono.UIAutomation.Winforms
 		private PropertyGridListItemProvider[] Children
 		{
 			get {
-				return Navigation.GetChildren ().Cast<PropertyGridListItemProvider> ().ToArray ();
+				return Navigation.GetChildren ().OfType<PropertyGridListItemProvider> ().ToArray ();
 			}
 		}
 

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/PropertyGridViewProvider.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/PropertyGridViewProvider.cs
@@ -165,8 +165,7 @@ namespace Mono.UIAutomation.Winforms
 				return null;
 		}
 
-		public override IProviderBehavior GetListItemBehaviorRealization (AutomationPattern behavior,
-				ListItemProvider listItem)
+		public override IProviderBehavior GetListItemBehaviorRealization (AutomationPattern behavior, ListItemProvider listItem)
 		{
 			if (behavior == SelectionItemPatternIdentifiers.Pattern)
 				return new ListItemSelectionItemProviderBehavior (listItem);
@@ -174,8 +173,8 @@ namespace Mono.UIAutomation.Winforms
 				return new ListItemGridItemProviderBehavior (listItem);
 			else if (behavior == TableItemPatternIdentifiers.Pattern)
 				return new ListItemTableItemProviderBehavior (listItem);
-			else if (behavior == LegacyIAccessiblePatternIdentifiers.Pattern)
-				return new ListItemLegacyIAccessibleProviderBehavior (listItem);
+			else if (behavior == LegacyIAccessiblePatternIdentifiers.Pattern && (listItem is PropertyGridListItemProvider gridEntryProvider))
+				return new GridItemLegacyIAccessibleProviderBehavior (gridEntryProvider);
 			else
 				return base.GetListItemBehaviorRealization (behavior, listItem);
 		}
@@ -348,7 +347,7 @@ namespace Mono.UIAutomation.Winforms
 			base.Initialize();
 
 			SetBehavior (LegacyIAccessiblePatternIdentifiers.Pattern,
-				ListProvider.GetListItemBehaviorRealization (LegacyIAccessiblePatternIdentifiers.Pattern, this));
+				PropertyGridViewProvider.GetListItemBehaviorRealization (LegacyIAccessiblePatternIdentifiers.Pattern, this));
 		}
 
 #region Public Properties
@@ -373,7 +372,7 @@ namespace Mono.UIAutomation.Winforms
 		}
 		
 		public PropertyGridViewProvider PropertyGridViewProvider {
-			get { return viewProvider; }
+			get { return (PropertyGridViewProvider)ListProvider; }
 		}
 
 		public GridEntry Entry {
@@ -387,11 +386,8 @@ namespace Mono.UIAutomation.Winforms
 		                                     GridEntry entry) 
 			: base (viewProvider, viewProvider, null, entry)
 		{
-			this.viewProvider = viewProvider;
 			this.view = view;
 			this.entry = entry;
-
-			this.viewProvider.ToString ();
 		}
 
 		public override void InitializeChildControlStructure ()
@@ -431,7 +427,6 @@ namespace Mono.UIAutomation.Winforms
 		private PropertyGridListItemChildProvider nameProvider;
 		private PropertyGridListItemValueProvider valueProvider;
 
-		private PropertyGridViewProvider viewProvider;
 		private PropertyGridView view;
 		private GridEntry entry;
 #endregion

--- a/UIAutomationWinforms/UIAutomationWinforms/UIAutomationWinforms.csproj
+++ b/UIAutomationWinforms/UIAutomationWinforms/UIAutomationWinforms.csproj
@@ -160,9 +160,9 @@
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PrintPreviewControl\ScrollProviderBehavior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\ProgressBar\RangeValueProviderBehavior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\CategoryInvokeProviderBehavior.cs" />
+    <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\GridItemLegacyIAccessibleProviderBehavior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\GridProviderBehavior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\ListItemChildValueProviderBeahvior.cs" />
-    <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\ListItemLegacyIAccessibleProviderBehavior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\ListItemGridItemProviderBehavior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\ListItemNameValueProviderBeahvior.cs" />
     <Compile Include="Mono.UIAutomation.Winforms.Behaviors\PropertyGrid\ListItemSelectionItemProviderBehavior.cs" />

--- a/UiaDbus/UiaDbus/Interfaces/ILegacyIAccessiblePattern.cs
+++ b/UiaDbus/UiaDbus/Interfaces/ILegacyIAccessiblePattern.cs
@@ -39,5 +39,7 @@ namespace Mono.UIAutomation.UiaDbus.Interfaces
 		int Role { get; }  // CLS-compliantment requires signed int instead of UInt32
 		int State { get; }  // CLS-compliantment requires signed int instead of UInt32
 		string Value { get; }
+
+		void DoDefaultAction ();
 	}
 }

--- a/UiaDbus/UiaDbusBridge/Wrappers/LegacyIAccessiblePatternWrapper.cs
+++ b/UiaDbus/UiaDbusBridge/Wrappers/LegacyIAccessiblePatternWrapper.cs
@@ -102,6 +102,11 @@ namespace Mono.UIAutomation.UiaDbusBridge.Wrappers
 			}
 		}
 
+		public void DoDefaultAction ()
+		{
+			provider.DoDefaultAction ();
+		}
+
 #endregion
 	}
 }

--- a/UiaDbus/UiaDbusSource/UiaDbusLegacyIAccessiblePattern.cs
+++ b/UiaDbus/UiaDbusSource/UiaDbusLegacyIAccessiblePattern.cs
@@ -131,5 +131,15 @@ namespace Mono.UIAutomation.UiaDbusSource
 				}
 			}
 		}
+
+		public void DoDefaultAction ()
+		{
+			try {
+				pattern.DoDefaultAction ();
+			} catch (Exception ex) {
+				throw DbusExceptionTranslator.Translate (ex);
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
- Track grid items state update and represent CategoryGridEntry in UIA API. One need https://github.com/mono/mono/pull/17731.
- Implement `DoDefaultAction` method (LegacyIAccessible pattern) for `GridItem`