### PR TITLE
Fix crash on remove item from `DataGridView`

### DIFF
--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Events/DataGridView/DataItemChildGridItemPatternColumnEvent.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Events/DataGridView/DataItemChildGridItemPatternColumnEvent.cs
@@ -37,8 +37,7 @@ namespace Mono.UIAutomation.Winforms.Events.DataGridView
 		#region Constructors
 
 		public DataItemChildGridItemPatternColumnEvent (DataGridViewProvider.DataGridViewDataItemChildProvider provider)
-			: base (provider, 
-			        GridItemPatternIdentifiers.ColumnProperty)
+			: base (provider, GridItemPatternIdentifiers.ColumnProperty)
 		{
 			this.provider = provider;
 		}
@@ -49,20 +48,19 @@ namespace Mono.UIAutomation.Winforms.Events.DataGridView
 
 		public override void Connect ()
 		{
-			provider.Cell.DataGridView.Columns.CollectionChanged += OnColumnPropertyEvent;
+			provider.DataGridViewProvider.DataGridView.Columns.CollectionChanged += OnColumnPropertyEvent;
 		}
 
 		public override void Disconnect ()
 		{
-			provider.Cell.DataGridView.Columns.CollectionChanged -= OnColumnPropertyEvent;
+			provider.DataGridViewProvider.DataGridView.Columns.CollectionChanged -= OnColumnPropertyEvent;
 		}
 		
 		#endregion 
 		
 		#region Private methods
 
-		private void OnColumnPropertyEvent (object sender, 
-		                                    CollectionChangeEventArgs args)
+		private void OnColumnPropertyEvent (object sender, CollectionChangeEventArgs args)
 		{
 			RaiseAutomationPropertyChangedEvent ();
 		}

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Events/DataGridView/DataItemChildGridItemPatternRowEvent.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Events/DataGridView/DataItemChildGridItemPatternRowEvent.cs
@@ -37,8 +37,7 @@ namespace Mono.UIAutomation.Winforms.Events.DataGridView
 		#region Constructors
 
 		public DataItemChildGridItemPatternRowEvent (DataGridViewProvider.DataGridViewDataItemChildProvider provider)
-			: base (provider, 
-			        GridItemPatternIdentifiers.RowProperty)
+			: base (provider, GridItemPatternIdentifiers.RowProperty)
 		{
 			this.provider = provider;
 		}
@@ -49,20 +48,19 @@ namespace Mono.UIAutomation.Winforms.Events.DataGridView
 
 		public override void Connect ()
 		{
-			provider.Cell.DataGridView.Rows.CollectionChanged += OnRowPropertyEvent;
+			provider.DataGridViewProvider.DataGridView.Rows.CollectionChanged += OnRowPropertyEvent;
 		}
 
 		public override void Disconnect ()
 		{
-			provider.Cell.DataGridView.Rows.CollectionChanged -= OnRowPropertyEvent;
+			provider.DataGridViewProvider.DataGridView.Rows.CollectionChanged -= OnRowPropertyEvent;
 		}
 		
 		#endregion 
-		
+
 		#region Private methods
 
-		private void OnRowPropertyEvent (object sender, 
-		                                 CollectionChangeEventArgs args)
+		private void OnRowPropertyEvent (object sender, CollectionChangeEventArgs args)
 		{
 			RaiseAutomationPropertyChangedEvent ();
 		}

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Events/DataGridView/DataItemChildTableItemColumnHeaderItemsEvent.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms.Events/DataGridView/DataItemChildTableItemColumnHeaderItemsEvent.cs
@@ -38,8 +38,7 @@ namespace Mono.UIAutomation.Winforms.Events.DataGridView
 		#region Constructors
 
 		public DataItemChildTableItemColumnHeaderItemsEvent (DataGridViewProvider.DataGridViewDataItemChildProvider provider)
-			: base (provider,
-			        TableItemPatternIdentifiers.ColumnHeaderItemsProperty)
+			: base (provider, TableItemPatternIdentifiers.ColumnHeaderItemsProperty)
 		{
 			this.provider = provider;
 		}
@@ -50,20 +49,19 @@ namespace Mono.UIAutomation.Winforms.Events.DataGridView
 
 		public override void Connect ()
 		{
-			provider.Cell.DataGridView.Columns.CollectionChanged += OnColumnHeaderItemsEvent;
+			provider.DataGridViewProvider.DataGridView.Columns.CollectionChanged += OnColumnHeaderItemsEvent;
 		}
 
 		public override void Disconnect ()
 		{
-			provider.Cell.DataGridView.Columns.CollectionChanged -= OnColumnHeaderItemsEvent;
+			provider.DataGridViewProvider.DataGridView.Columns.CollectionChanged -= OnColumnHeaderItemsEvent;
 		}
 		
 		#endregion 
 		
 		#region Private methods
 		
-		private void OnColumnHeaderItemsEvent (object sender, 
-		                                       CollectionChangeEventArgs args)
+		private void OnColumnHeaderItemsEvent (object sender, CollectionChangeEventArgs args)
 		{
 			RaiseAutomationPropertyChangedEvent ();
 		}

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/DataGridViewProvider.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/DataGridViewProvider.cs
@@ -225,6 +225,7 @@ namespace Mono.UIAutomation.Winforms
 			AddChildProvider (header);
 
 			datagridview.Rows.CollectionChanged += OnCollectionChanged;
+
 			foreach (SWF.DataGridViewRow row in datagridview.Rows) {
 				ListItemProvider itemProvider = GetItemProviderFrom (this, row);
 				AddChildProvider (itemProvider);

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/SimpleControlProvider.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/SimpleControlProvider.cs
@@ -170,7 +170,7 @@ namespace Mono.UIAutomation.Winforms
 		{
 			IConnectable value;
 			
-			if (events.TryGetValue (type, out value) == true) {			
+			if (events.TryGetValue (type, out value) == true) {
 				value.Disconnect ();
 				events.Remove (type);
 			}


### PR DESCRIPTION
`Disconnect` methods fails due to `provider.Cell.DataGridView` is `null` -- see calls of `{some_row}.SetDataGridView (null);` in `DataGridViewRowCollection.Remove(...)` and `DataGridViewRowCollection.Clear()` (https://github.com/mono/mono/blob/mono-6.4.0.198/mcs/class/System.Windows.Forms/System.Windows.Forms/DataGridViewRowCollection.cs).