### PR TITLE
Try to correct Navigation tree errors on fly

### DIFF
--- a/UIAutomation/Makefile.am
+++ b/UIAutomation/Makefile.am
@@ -3,7 +3,7 @@ EXTRA_DIST = \
 	mono.snk \
 	winfx3.pub
 
- CODE_SUBDIRS = UIAutomationTypes UIAutomationBridge UIAutomationProvider UIAutomationSource UIAutomationClient
+ CODE_SUBDIRS = UIAutomationHelpers UIAutomationTypes UIAutomationBridge UIAutomationProvider UIAutomationSource UIAutomationClient
 
 if ENABLE_TESTS
  SUBDIRS = $(CODE_SUBDIRS) UIAutomationClientTests data

--- a/UIAutomation/README
+++ b/UIAutomation/README
@@ -12,6 +12,7 @@ http://www.mono-project.com/Accessibility
 Implementation of Microsoft UI Automation (UIA) assemblies.  This package
 provides the following assemblies:
 
+	UIAutomationHelpers.dll Internal helpers public for other assemblies.
 	UIAutomationTypes.dll: Types, constants, and identifiers.
 	UIAutomationProvider.dll: Provider pattern interface definitions.
 	UIAutomationClient.dll: Types used by UIA clients to get element info.

--- a/UIAutomation/UIAutomation.sln
+++ b/UIAutomation/UIAutomation.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 10.00
 # Visual Studio 2008
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationHelpers", "UIAutomationHelpers\UIAutomationHelpers.csproj", "{88145e4d-d19c-4789-8b69-75cc5590a31e}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationTypes", "UIAutomationTypes\UIAutomationTypes.csproj", "{876B87EE-FBD3-400D-891E-BE0589072CDF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIAutomationBridge", "UIAutomationBridge\UIAutomationBridge.csproj", "{2E55F936-770A-405E-A1F0-209FD2C34AF8}"
@@ -16,6 +18,8 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{88145e4d-d19c-4789-8b69-75cc5590a31e}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88145e4d-d19c-4789-8b69-75cc5590a31e}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E55F936-770A-405E-A1F0-209FD2C34AF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2E55F936-770A-405E-A1F0-209FD2C34AF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E7CEBB8-47CA-406F-BF63-FBB17D5DE08A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/UIAutomation/UIAutomationBridge/Mono.UIAutomation.Bridge/UiTaskSchedulerHolder.cs
+++ b/UIAutomation/UIAutomationBridge/Mono.UIAutomation.Bridge/UiTaskSchedulerHolder.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Threading.Tasks;
+using Mono.UIAutomation.Helpers;
 using Mono.UIAutomation.Services;
 
 namespace Mono.UIAutomation.Bridge
 {
 	public static class UiTaskSchedulerHolder
 	{
-		private const string EnvVarName = "MONO_UIA_UISYNCCONTEXT";
-		private const string EnvVarTrue = "1";
-		private const string EnvVarFlase = "0";
 		private static TaskScheduler  _uiTaskScheduler = null;
 		private static bool _warnMsgShown = false;
 
@@ -16,14 +14,14 @@ namespace Mono.UIAutomation.Bridge
 		{
 			get
 			{
-				var envVarUseUiSyncContext = IsEnvVarUseUiSyncContext ();
+				var envVarUseUiSyncContext = EnvironmentVaribles.MONO_UIA_UISYNCCONTEXT;
 				if (_uiTaskScheduler != null && envVarUseUiSyncContext)
 					return _uiTaskScheduler;
 
 				if (!_warnMsgShown) {
 					var msg = envVarUseUiSyncContext
-						? "[UiTaskSchedulerHolder]: UI SynchronizationContext is not set to deal with WinForms controls."
-						: $"[UiTaskSchedulerHolder]: UI SynchronizationContext is not going to be used by means of '{EnvVarName}' environment viriable.";
+						? $"[UiTaskSchedulerHolder]: UI SynchronizationContext is not set to deal with WinForms controls."
+						: $"[UiTaskSchedulerHolder]: UI SynchronizationContext is not going to be used by means of 'MONO_UIA_UISYNCCONTEXT' environment viriable.";
 					Console.WriteLine (msg);
 					_warnMsgShown = true;
 				}
@@ -38,20 +36,6 @@ namespace Mono.UIAutomation.Bridge
 		{
 			if (_uiTaskScheduler == null)
 			 	_uiTaskScheduler = TaskScheduler.FromCurrentSynchronizationContext ();
-		}
-
-		private static bool IsEnvVarUseUiSyncContext ()
-		{
-			var envVar = Environment.GetEnvironmentVariable (EnvVarName);
-			if (envVar == null || envVar == "1")
-				return true;
-			if (envVar == "0")
-				return false;
-			
-			var msg = $"[UiTaskSchedulerHolder]: Environment variable '{EnvVarName}' (currently set to '{envVar}')"
-				+ $" may be set to '{EnvVarFlase}' or '{EnvVarTrue}' only. Unset variable is equal to '{EnvVarTrue}'.";
-			Console.WriteLine (msg);
-			throw new Exception (msg);
 		}
 	}
 }

--- a/UIAutomation/UIAutomationBridge/Mono.UIAutomation.Services/Log.cs
+++ b/UIAutomation/UIAutomationBridge/Mono.UIAutomation.Services/Log.cs
@@ -24,6 +24,7 @@
 // 
 
 using System;
+using Mono.UIAutomation.Helpers;
 
 namespace Mono.UIAutomation.Services
 {
@@ -49,7 +50,7 @@ namespace Mono.UIAutomation.Services
 #region Public Methods
 		static Log ()
 		{
-			string level = Environment.GetEnvironmentVariable ("MONO_UIA_LOG_LEVEL");
+			string level = EnvironmentVaribles.MONO_UIA_LOG_LEVEL;
 			if (level != null) {
 				try {
 					currentLogLevel = (LogLevel) Convert.ToInt32 (level);

--- a/UIAutomation/UIAutomationClient/Makefile.am
+++ b/UIAutomation/UIAutomationClient/Makefile.am
@@ -92,6 +92,7 @@ REFERENCES =  \
 	System \
 	System.Core \
 	Mono.Posix \
+	UIAutomationHelpers \
 	$(GTK_SHARP_30_LIBS)
 
 DLL_REFERENCES = 

--- a/UIAutomation/UIAutomationHelpers/AssemblyInfo.cs.in
+++ b/UIAutomation/UIAutomationHelpers/AssemblyInfo.cs.in
@@ -1,0 +1,49 @@
+﻿// Permission is hereby granted, free of charge, to any person obtaining 
+// a copy of this software and associated documentation files (the 
+// "Software"), to deal in the Software without restriction, including 
+// without limitation the rights to use, copy, modify, merge, publish, 
+// distribute, sublicense, and/or sell copies of the Software, and to 
+// permit persons to whom the Software is furnished to do so, subject to 
+// the following conditions: 
+//  
+// The above copyright notice and this permission notice shall be 
+// included in all copies or substantial portions of the Software. 
+//  
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE 
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+// 
+// Copyright (c) 2020 AxxonSoft (http://axxonsoft.com)
+//
+// Authors:
+//   Nikita Voronchev <nikita.voronchev@ru.axxonsoft.com>
+// 
+
+using System;
+using System.Resources;
+using System.Reflection;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: AssemblyCompany (Consts.MonoCompany)]
+[assembly: AssemblyProduct (Consts.MonoProduct)]
+[assembly: AssemblyCopyright (Consts.MonoCopyright)]
+[assembly: AssemblyVersion (Consts.FxVersion)]
+[assembly: AssemblyFileVersion (Consts.WinFileVersion)]
+
+[assembly: NeutralResourcesLanguage ("en")]
+[assembly: CLSCompliant (true)]
+
+[assembly: ComVisible (false)]
+[assembly: AllowPartiallyTrustedCallers]
+
+[assembly: CompilationRelaxations (CompilationRelaxations.NoStringInterning)]
+[assembly: Debuggable (DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: RuntimeCompatibility (WrapNonExceptionThrows = true)]

--- a/UIAutomation/UIAutomationHelpers/Makefile.am
+++ b/UIAutomation/UIAutomationHelpers/Makefile.am
@@ -2,40 +2,38 @@
 EXTRA_DIST =  
 
 ASSEMBLY_COMPILER_COMMAND = mcs
-ASSEMBLY_COMPILER_FLAGS = -lib:@expanded_libdir@/mono/2.0 -lib:../bin -lib:@expanded_libdir@/mono/accessibility -noconfig -codepage:utf8 -warn:4 -warnaserror -optimize+ -debug "-define:DEBUG" -d:NET_2_0 -delaysign+ -keyfile:@abs_top_srcdir@/winfx3.pub
+ASSEMBLY_COMPILER_FLAGS = -lib:@expanded_libdir@/mono/2.0 -lib:../bin -noconfig -codepage:utf8 -warn:4 -warnaserror -optimize+ -debug "-define:DEBUG" -d:NET_2_0 -delaysign+ -keyfile:@abs_top_srcdir@/winfx3.pub
 
-ASSEMBLY = ../bin/UIAutomationBridge.dll
+ASSEMBLY = ../bin/UIAutomationHelpers.dll
 ASSEMBLY_MDB = $(ASSEMBLY).mdb
 COMPILE_TARGET = library
 PROJECT_REFERENCES = 
 BUILD_DIR = ../bin
 PACKAGE_FLAG = /package accessibility
 
-UIAUTOMATIONBRIDGE_DLL_MDB_SOURCE=../bin/UIAutomationBridge.dll.mdb
-UIAUTOMATIONBRIDGE_DLL_MDB=$(BUILD_DIR)/UIAutomationBridge.dll.mdb
+UIAUTOMATIONHELPERS_DLL_MDB_SOURCE=../bin/UIAutomationHelpers.dll.mdb
+UIAUTOMATIONHELPERS_DLL_MDB=$(BUILD_DIR)/UIAutomationHelpers.dll.mdb
+
 
 AL=al2
-SATELLITE_ASSEMBLY_NAME=Mono.UIAutomation.Bridge.resources.dll
+SATELLITE_ASSEMBLY_NAME=Mono.UIAutomation.Helpers.resources.dll
 
 PROGRAMFILES = \
-	$(UIAUTOMATIONBRIDGE_DLL_MDB)  
+	$(UIAUTOMATIONHELPERS_DLL_MDB)
 
 
 RESGEN=resgen2
-	
+
 all: $(ASSEMBLY) $(PROGRAMFILES)
 
 PROJECT_SOURCE_FILES =  \
-	Mono.UIAutomation.Bridge/IAutomationBridge.cs \
-	Mono.UIAutomation.Bridge/IHypertext.cs \
-	Mono.UIAutomation.Bridge/UiTaskSchedulerHolder.cs \
-	Mono.UIAutomation.Services/ArgumentCheck.cs \
-	Mono.UIAutomation.Services/Log.cs
+	Mono.UIAutomation.Helpers/EnvironmentVaribles.cs
 
 FILES =  \
-        AssemblyInfo.cs \
-        ../build/common/*.cs \
+	AssemblyInfo.cs \
+	../build/common/*.cs \
 	$(PROJECT_SOURCE_FILES)
+
 
 DATA_FILES = 
 
@@ -44,8 +42,7 @@ RESOURCES =
 REFERENCES =  \
 	WindowsBase \
 	System \
-	UIAutomationHelpers \
-	UIAutomationTypes
+	System.Core
 
 DLL_REFERENCES = 
 

--- a/UIAutomation/UIAutomationHelpers/Mono.UIAutomation.Helpers/EnvironmentVaribles.cs
+++ b/UIAutomation/UIAutomationHelpers/Mono.UIAutomation.Helpers/EnvironmentVaribles.cs
@@ -1,0 +1,87 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Copyright (c) 2020 AxxonSoft (http://axxonsoft.com)
+//
+// Authors:
+//   Nikita Voronchev <nikita.voronchev@ru.axxonsoft.com>
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mono.UIAutomation.Helpers
+{
+    public enum MONO_UIA_NAVIGATION_TREE_ERR
+    {
+        Log,
+        Exception
+    }
+
+    public static class EnvironmentVaribles
+    {
+        public static bool MONO_UIA_UISYNCCONTEXT => GetEnvVarIntValueAsBoolOrDefault ("MONO_UIA_UISYNCCONTEXT", true);
+
+        public static bool MONO_UIA_ENABLED => GetEnvVarIntValueAsBoolOrDefault ("MONO_UIA_ENABLED", true);
+
+        public static string MONO_UIA_SOURCE => GetEnvVarValueOrDefault<string> ("MONO_UIA_SOURCE", string.Empty);
+
+        public static string MONO_UIA_BRIDGE => GetEnvVarValueOrDefault<string> ("MONO_UIA_BRIDGE", string.Empty);
+
+        public static MONO_UIA_NAVIGATION_TREE_ERR MONO_UIA_NAVIGATION_TREE_ERR =>
+            GetEnvVarValueAsEnumOrDefault<MONO_UIA_NAVIGATION_TREE_ERR> ("MONO_UIA_NAVIGATION_TREE_ERR", MONO_UIA_NAVIGATION_TREE_ERR.Log);
+
+        public static string MONO_UIA_LOG_LEVEL => Environment.GetEnvironmentVariable ("MONO_UIA_LOG_LEVEL");
+
+        private static bool GetEnvVarIntValueAsBoolOrDefault (string envVarName, bool defaultValue)
+        {
+            var defaultIntValue = Convert.ToInt32 (defaultValue);
+
+            var intVal = GetEnvVarValueOrDefault<int> (envVarName, defaultIntValue);
+            if (intVal >= 0)
+                return Convert.ToBoolean (intVal);
+
+            var msg = $"[EnvironmentVaribles]: Environment variable '{envVarName}' (currently set to '{intVal}')"
+                + $" may be set to '0' or '1' only. Unset variable is equal to '{defaultIntValue}'.";
+            Console.WriteLine (msg);
+            throw new Exception (msg);
+        }
+
+        private static T GetEnvVarValueOrDefault<T> (string envVarName, T defaultValue)
+        {
+            var envValue = Environment.GetEnvironmentVariable (envVarName);
+            var value = string.IsNullOrWhiteSpace(envValue)
+                ? defaultValue
+                : (T) Convert.ChangeType (envValue, typeof(T));
+            return value;
+        }
+
+        private static T GetEnvVarValueAsEnumOrDefault<T> (string envVarName, T defaultValue ) where T : struct
+        {
+            var envValue = Environment.GetEnvironmentVariable (envVarName);
+            if (string.IsNullOrWhiteSpace (envValue))
+                return defaultValue;
+
+            if (Enum.TryParse (envValue, true, out T value))
+                return value;
+            else
+                throw new Exception ($"[EnvironmentVaribles]: Cann't convert {envVarName}='{envValue}' to enum {typeof(T)}={{{string.Join(',', Enum.GetNames (typeof(T)))}}}");
+        }
+    }
+}

--- a/UIAutomation/UIAutomationHelpers/UIAutomationHelpers.csproj
+++ b/UIAutomation/UIAutomationHelpers/UIAutomationHelpers.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{88145e4d-d19c-4789-8b69-75cc5590a31e}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>UIAutomationHelpers</RootNamespace>
+    <AssemblyName>UIAutomationHelpers</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Mono.UIAutomation.Helpers\Environment.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <MonoDevelop.Autotools.MakefileInfo IntegrationEnabled="true" RelativeMakefileName="Makefile.am">
+          <BuildFilesVar Sync="true" Name="PROJECT_SOURCE_FILES" />
+          <DeployFilesVar />
+          <ResourcesVar Name="RESOURCES" />
+          <OthersVar />
+          <GacRefVar Name="REFERENCES" />
+          <AsmRefVar Name="REFERENCES" />
+          <ProjectRefVar Name="REFERENCES" />
+        </MonoDevelop.Autotools.MakefileInfo>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+</Project>

--- a/UIAutomation/UIAutomationProvider/Makefile.am
+++ b/UIAutomation/UIAutomationProvider/Makefile.am
@@ -73,6 +73,7 @@ REFERENCES =  \
 	WindowsBase \
 	System \
 	System.Core \
+	UIAutomationHelpers \
 	UIAutomationBridge \
 	UIAutomationTypes
 

--- a/UIAutomation/UIAutomationProvider/System.Windows.Automation.Provider/AutomationInteropProvider.cs
+++ b/UIAutomation/UIAutomationProvider/System.Windows.Automation.Provider/AutomationInteropProvider.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 using Mono.UIAutomation.Bridge;
+using Mono.UIAutomation.Helpers;
 
 namespace System.Windows.Automation.Provider
 {
@@ -117,8 +118,6 @@ namespace System.Windows.Automation.Provider
 	
 	internal static class BridgeManager
 	{
-		private const string UIA_ENABLED_ENV_VAR = "MONO_UIA_ENABLED";
-		private const string BRIDGE_ASSEMBLY_NAMES_ENV_VAR = "MONO_UIA_BRIDGE";
 		private const char BRIDGE_ASSEMBLY_NAMES_DELIM = ';';
 
 		private static string UiaAtkBridgeAssembly =
@@ -130,25 +129,15 @@ namespace System.Windows.Automation.Provider
 
 		public static IList<IAutomationBridge> GetAutomationBridges ()
 		{
-			bool isUiaEnabled = true;
-			
-			var isUiaEnabledEnvVar = Environment.GetEnvironmentVariable (UIA_ENABLED_ENV_VAR);
-			if (!string.IsNullOrEmpty(isUiaEnabledEnvVar))
-			{
-				if (isUiaEnabledEnvVar == "0")
-					isUiaEnabled = false;
-				else if (isUiaEnabledEnvVar != "1")
-					throw new Exception($"The environment varianble '{UIA_ENABLED_ENV_VAR}' may be equal to '0' and '1' only, or may be empty or undefined.");
-			}
-
+			bool isUiaEnabled = EnvironmentVaribles.MONO_UIA_ENABLED;
 			if (!isUiaEnabled) {
-				Console.WriteLine ($"No one UIA bridge is loaded: {UIA_ENABLED_ENV_VAR}='{isUiaEnabledEnvVar}'");
+				Console.WriteLine ($"No one UIA bridge is loaded: MONO_UIA_ENABLED='{Convert.ToInt32 (isUiaEnabled)}'");
 				return new List<IAutomationBridge> ();
 			}
 
 			// Let MONO_UIA_BRIDGE env var override default bridge
 			List<string> bridgeAssemblyNames =
-				(Environment.GetEnvironmentVariable (BRIDGE_ASSEMBLY_NAMES_ENV_VAR) ?? string.Empty)
+				EnvironmentVaribles.MONO_UIA_BRIDGE
 				.Split (BRIDGE_ASSEMBLY_NAMES_DELIM)
 				.Where (name => !string.IsNullOrEmpty(name))
 				.ToList ();
@@ -165,7 +154,7 @@ namespace System.Windows.Automation.Provider
 
 			var loadedBridgesMsg = new List<string> { "Loaded UIA bridges:" };
 			loadedBridgesMsg.AddRange (namedBridges.Select (x => x.name));
-			loadedBridgesMsg.Add ($"* To disable UIA bridges loading set environment variable {UIA_ENABLED_ENV_VAR} to '0'. *");
+			loadedBridgesMsg.Add ($"*** To disable UIA bridges loading set environment variable MONO_UIA_ENABLED to '0'. ***");
 			Console.WriteLine (string.Join (Environment.NewLine + "  ", loadedBridgesMsg));
 
 			return namedBridges.Select (x => x.bridge).ToList ();

--- a/UIAutomation/configure.ac
+++ b/UIAutomation/configure.ac
@@ -94,6 +94,8 @@ PKG_CHECK_MODULES([GLIB_SHARP_30], [glib-sharp-3.0 >= 2.99.1])
 PKG_CHECK_MODULES([GTK_SHARP_30], [gtk-sharp-3.0 >= 2.99.1])
 
 AC_CONFIG_FILES([
+UIAutomationHelpers/Makefile
+UIAutomationHelpers/AssemblyInfo.cs
 UIAutomationTypes/Makefile
 UIAutomationTypes/AssemblyInfo.cs
 UIAutomationBridge/Makefile

--- a/UIAutomation/data/mono-uia-Fedora_12.spec.in
+++ b/UIAutomation/data/mono-uia-Fedora_12.spec.in
@@ -63,6 +63,8 @@ rm -rf %{buildroot}
 %{_libdir}/mono/accessibility
 %{_libdir}/mono/gac/UIAutomationProvider
 %{_libdir}/mono/accessibility/UIAutomationProvider.dll
+%{_libdir}/mono/gac/UIAutomationHelpers
+%{_libdir}/mono/accessibility/UIAutomationHelpers.dll
 %{_libdir}/mono/gac/UIAutomationTypes
 %{_libdir}/mono/accessibility/UIAutomationTypes.dll
 %{_libdir}/mono/gac/UIAutomationBridge

--- a/UIAutomation/data/mono-uia-Fedora_13.spec.in
+++ b/UIAutomation/data/mono-uia-Fedora_13.spec.in
@@ -53,6 +53,8 @@ rm -rf %{buildroot}
 %{_libdir}/mono/accessibility
 %{_libdir}/mono/gac/UIAutomationProvider
 %{_libdir}/mono/accessibility/UIAutomationProvider.dll
+%{_libdir}/mono/gac/UIAutomationHelpers
+%{_libdir}/mono/accessibility/UIAutomationHelpers.dll
 %{_libdir}/mono/gac/UIAutomationTypes
 %{_libdir}/mono/accessibility/UIAutomationTypes.dll
 %{_libdir}/mono/gac/UIAutomationBridge

--- a/UIAutomation/data/mono-uia-libdir-fedora.patch
+++ b/UIAutomation/data/mono-uia-libdir-fedora.patch
@@ -72,7 +72,19 @@ diff -uraN mono-uia-1.0.orig/UIAutomationProvider/Makefile.in mono-uia-1.0/UIAut
 -GACROOT = $(DESTDIR)$(prefix)/lib
 +GACROOT = $(DESTDIR)$(libdir)
  all: all-am
- 
+
+ .SUFFIXES:
+diff -uraN mono-uia-1.0.orig/UIAutomationHelpers/Makefile.in mono-uia-1.0/UIAutomationHelpers/Makefile.in
+--- mono-uia-1.0.orig/UIAutomationHelpers/Makefile.in	2009-05-21 01:10:48.553261633 +0200
++++ mono-uia-1.0/UIAutomationHelpers/Makefile.in	2009-05-21 01:15:06.158289227 +0200
+@@ -351,7 +351,7 @@
+ culture_resource_commandlines = $(call unesc2,cmd_line_satellite_$1 += '/embed:$(subst .resx,.resources,$2)')
+ build_satellite_assembly_list = $(call q2s,$(cultures:%=$(BUILD_DIR)/%/$(SATELLITE_ASSEMBLY_NAME)))
+ build_culture_res_files = $(call q2s,$(foreach res, $(culture_resources),$(call get_resource_name,$(res))))
+-GACROOT = $(DESTDIR)$(prefix)/lib
++GACROOT = $(DESTDIR)$(libdir)
+ all: all-am
+
  .SUFFIXES:
 diff -uraN mono-uia-1.0.orig/UIAutomationTypes/Makefile.in mono-uia-1.0/UIAutomationTypes/Makefile.in
 --- mono-uia-1.0.orig/UIAutomationTypes/Makefile.in	2009-05-21 01:10:48.553261633 +0200

--- a/UIAutomation/data/mono-uia-openSUSE_11.2.spec.in
+++ b/UIAutomation/data/mono-uia-openSUSE_11.2.spec.in
@@ -69,6 +69,8 @@ rm -rf %{buildroot}
 %{_prefix}/lib/mono/accessibility
 %{_prefix}/lib/mono/gac/UIAutomationProvider
 %{_prefix}/lib/mono/accessibility/UIAutomationProvider.dll
+%{_prefix}/lib/mono/gac/UIAutomationHelpers
+%{_prefix}/lib/mono/accessibility/UIAutomationHelpers.dll
 %{_prefix}/lib/mono/gac/UIAutomationTypes
 %{_prefix}/lib/mono/accessibility/UIAutomationTypes.dll
 %{_prefix}/lib/mono/gac/UIAutomationBridge

--- a/UIAutomation/data/mono-uia-openSUSE_11.3.spec.in
+++ b/UIAutomation/data/mono-uia-openSUSE_11.3.spec.in
@@ -61,6 +61,8 @@ rm -rf %{buildroot}
 %{_prefix}/lib/mono/accessibility
 %{_prefix}/lib/mono/gac/UIAutomationProvider
 %{_prefix}/lib/mono/accessibility/UIAutomationProvider.dll
+%{_prefix}/lib/mono/gac/UIAutomationHelpers
+%{_prefix}/lib/mono/accessibility/UIAutomationHelpers.dll
 %{_prefix}/lib/mono/gac/UIAutomationTypes
 %{_prefix}/lib/mono/accessibility/UIAutomationTypes.dll
 %{_prefix}/lib/mono/gac/UIAutomationBridge

--- a/UIAutomation/data/mono-uia.pc.in.in
+++ b/UIAutomation/data/mono-uia.pc.in.in
@@ -2,4 +2,4 @@
 Name: UIAutomation Libraries
 Description: UIAutomation implementation for Mono.
 Version: @VERSION@
-Libs: -r:@a11ydir@/UIAutomationTypes.dll -r:@a11ydir@/UIAutomationBridge.dll -r:@a11ydir@/UIAutomationProvider.dll -r:@a11ydir@/UIAutomationSource.dll -r:@a11ydir@/UIAutomationClient.dll -r:@windowsbase@
+Libs: -r:@a11ydir@/UIAutomationHelpers.dll -r:@a11ydir@/UIAutomationTypes.dll -r:@a11ydir@/UIAutomationBridge.dll -r:@a11ydir@/UIAutomationProvider.dll -r:@a11ydir@/UIAutomationSource.dll -r:@a11ydir@/UIAutomationClient.dll -r:@windowsbase@

--- a/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/FragmentControlProvider.cs
+++ b/UIAutomationWinforms/UIAutomationWinforms/Mono.UIAutomation.Winforms/FragmentControlProvider.cs
@@ -336,7 +336,7 @@ namespace Mono.UIAutomation.Winforms
 			}
 		}
 
-		protected void HandleChildComponentRemoved (Component childComponent)
+		internal void HandleChildComponentRemoved (Component childComponent)
 		{
 			var childProvider = Navigation.TryGetChild (childComponent);
 			if (childProvider == null)


### PR DESCRIPTION
Sometimes new child provider insertion event is ahead of the provider removal from the previous parent. This issue is unstable and appears in complicated UI applications.

To avoid crashes one may remove the child provider from the previous parent one by force. Current PR proposes this approach (please refer to the second commit https://github.com/mono/uia2atk/commit/0213fe63c976ca567a6e073b43142301440c08c0). New environment variable `MONO_UIA_NAVIGATION_TREE_ERR ` allows to change this behavior to an exception raising.